### PR TITLE
Integrate

### DIFF
--- a/MRS/api.py
+++ b/MRS/api.py
@@ -119,6 +119,13 @@ class GABA(object):
         self.creatine_signal = signal
         self.creatine_params = params
         self.cr_idx = fit_idx
+        mean_params = np.mean(params, 0)
+        self.creatine_auc = ana.integrate(ut.lorentzian,
+                                          self.f_ppm[self.idx],
+                                          tuple(mean_params),
+                                          offset = mean_params[-2],
+                                          drift = mean_params[-1])
+
         
     def fit_gaba(self, reject_outliers=3.0, fit_lb=2.8, fit_ub=3.4,
                  phase_correct=True):
@@ -165,8 +172,15 @@ class GABA(object):
         self.gaba_signal = signal
         self.gaba_params = params
         self.gaba_idx = gaba_idx
+        mean_params = np.mean(params, 0)
+        # Calculate AUC over the entire domain:
+        self.gaba_auc = ana.integrate(ut.gaussian,
+                                      self.f_ppm[self.idx],
+                                      tuple(mean_params),
+                                      offset = mean_params[-2],
+                                      drift = mean_params[-1])
 
-
+        
 class SingleVoxel(object):
     """
     Class for representation and analysis of single voxel experiments.

--- a/MRS/utils.py
+++ b/MRS/utils.py
@@ -467,7 +467,7 @@ def lorentzian(freq, freq0, area, hwhm, phase, offset, drift):
    absorptive = oo2pi * area * np.ones(freq.shape[0])*(hwhm / (df**2 + hwhm**2))
    dispersive = oo2pi * area * df/(df**2 + hwhm**2)
    return (absorptive * np.cos(phase) + dispersive * np.sin(phase) + offset +
-   drift * df)
+   drift * freq)
 
 def two_lorentzian(freq, freq0_1, freq0_2, area1, area2, hwhm1, hwhm2, phase1,
                    phase2, offset, drift):
@@ -488,7 +488,7 @@ def gaussian(freq, freq0, sigma, amp, offset, drift):
     A Gaussian function with flexible offset, drift and amplitude
     """
     return (amp * np.exp(- ((freq - freq0)**2) / (sigma**2) ) +
-            drift * (freq-freq0) + offset)
+            drift * freq + offset)
 
 def auc_gaussian(amp, sigma):
     """


### PR DESCRIPTION
Using trapezoidal integration, we can sum the AUC for the two models: Gaussian for the GABA peak and Lorentzian for the creatine peak. I ran this over our 13 naive volunteers, and usually get reasonable results. In some cases, the creatine or GABA peak may be displaced or appear smeared, in which case this fails miserably. Need to think of some way to robustify it. More TODO: fit the water peak in the water transients (another Lorentzian) and fit the glutamate/glutamine at 3.7 ppm (another Gaussian). Should both be rather easy, but I haven't done it yet. 
